### PR TITLE
Add strikethrough feature

### DIFF
--- a/src/app/shared/comment-editor/markdown-toolbar/markdown-toolbar.component.html
+++ b/src/app/shared/comment-editor/markdown-toolbar/markdown-toolbar.component.html
@@ -11,6 +11,11 @@
       <mat-icon>format_italic</mat-icon>
     </button>
   </md-italic>
+  <md-strikethrough>
+    <button matTooltip="Add strikethrough" mat-icon-button color="accent">
+      <mat-icon>format_strikethrough</mat-icon>
+    </button>
+  </md-strikethrough>
   <md-header>
     <button matTooltip="Add heading text" mat-icon-button color="accent">
       <mat-icon>title</mat-icon>


### PR DESCRIPTION
### Summary

- Adds a strikethrough button for users when they enter their comments for an issue.

### Changes Made

- Adds an additional strikethrough button using the same markdown-toolbar-element library

#### Before
<img width="1386" alt="image" src="https://github.com/joyngjr/CATcher/assets/97519138/1ab4a555-52fa-42dc-9171-d810830649c6">


#### After
<img width="1146" alt="image" src="https://github.com/joyngjr/CATcher/assets/97519138/449b583c-6bde-44d2-9f73-374c5e5d741c">


### Proposed Commit Message
```
Add strikethrough button for comments in issues
This allows testers/teams to be more creative when entering comments
```