### PR TITLE
add overview table for team-response phase

### DIFF
--- a/src/app/phase-team-response/issues-overview/issues-overview.component.css
+++ b/src/app/phase-team-response/issues-overview/issues-overview.component.css
@@ -1,0 +1,40 @@
+.container {
+  display: block;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.title {
+  color: black;
+  margin: 0;
+  padding: 30px 20px;
+}
+
+.mat-column-actions {
+  width: 13%;
+  text-align: center;
+}
+
+.mat-column-id {
+  width: 10%;
+}
+
+.mat-column-title {
+  width: 26%;
+}
+
+.mat-column-teamAssigned {
+  width: 10%;
+}
+
+.mat-column-type {
+  width: 12%;
+}
+
+.mat-column-severity {
+  width: 10%;
+}
+.mat-column-duplicateOf {
+  width: 12%;
+}

--- a/src/app/phase-team-response/issues-overview/issues-overview.component.html
+++ b/src/app/phase-team-response/issues-overview/issues-overview.component.html
@@ -1,0 +1,15 @@
+<div>
+  <mat-grid-list cols="3" rowHeight="80px">
+    <mat-grid-tile>
+      <div class="grid-flush-left"><h1 class="mat-headline" style="margin: 0">Issues Overview</h1></div>
+    </mat-grid-tile>
+
+    <mat-grid-tile>
+      <mat-form-field class="full-grid-width">
+        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
+      </mat-form-field>
+    </mat-grid-tile>
+  </mat-grid-list>
+
+  <app-issue-tables [headers]="this.displayedColumns" [actions]="this.actionButtons"></app-issue-tables>
+</div>

--- a/src/app/phase-team-response/issues-overview/issues-overview.component.ts
+++ b/src/app/phase-team-response/issues-overview/issues-overview.component.ts
@@ -1,0 +1,62 @@
+import { Component, Input, OnChanges, OnInit, SimpleChanges, ViewChild } from '@angular/core';
+import { Issue, STATUS } from '../../core/models/issue.model';
+import { UserRole } from '../../core/models/user.model';
+import { IssueService } from '../../core/services/issue.service';
+import { PermissionService } from '../../core/services/permission.service';
+import { UserService } from '../../core/services/user.service';
+import { TABLE_COLUMNS } from '../../shared/issue-tables/issue-tables-columns';
+import { ACTION_BUTTONS, IssueTablesComponent } from '../../shared/issue-tables/issue-tables.component';
+
+@Component({
+  selector: 'app-issues-overview',
+  templateUrl: './issues-overview.component.html',
+  styleUrls: ['./issues-overview.component.css']
+})
+export class IssuesOverviewComponent implements OnInit {
+  displayedColumns;
+  filter: (issue: Issue) => boolean;
+
+  readonly actionButtons: ACTION_BUTTONS[] = [
+    ACTION_BUTTONS.VIEW_IN_WEB,
+    ACTION_BUTTONS.RESPOND_TO_ISSUE,
+    ACTION_BUTTONS.MARK_AS_RESPONDED,
+    ACTION_BUTTONS.FIX_ISSUE
+  ];
+
+  @Input() teamFilter: string;
+
+  @ViewChild(IssueTablesComponent, { static: true }) table: IssueTablesComponent;
+
+  constructor(public issueService: IssueService, public permissions: PermissionService, public userService: UserService) {
+    if (userService.currentUser.role !== UserRole.Student) {
+      this.displayedColumns = [
+        TABLE_COLUMNS.ID,
+        TABLE_COLUMNS.TITLE,
+        TABLE_COLUMNS.TEAM_ASSIGNED,
+        TABLE_COLUMNS.TYPE,
+        TABLE_COLUMNS.SEVERITY,
+        TABLE_COLUMNS.DUPLICATED_ISSUES,
+        TABLE_COLUMNS.ACTIONS
+      ];
+    } else {
+      this.displayedColumns = [
+        TABLE_COLUMNS.ID,
+        TABLE_COLUMNS.TITLE,
+        TABLE_COLUMNS.TYPE,
+        TABLE_COLUMNS.SEVERITY,
+        TABLE_COLUMNS.DUPLICATED_ISSUES,
+        TABLE_COLUMNS.ACTIONS
+      ];
+    }
+  }
+
+  ngOnInit() {
+    const isNotDuplicate = (issue: Issue) => !issue.duplicateOf;
+    const hasNoParseErrors = (issue: Issue) => !issue.status || !issue.teamResponseError;
+    this.filter = (issue: Issue) => isNotDuplicate(issue) && hasNoParseErrors(issue);
+  }
+
+  applyFilter(filterValue: string) {
+    this.table.issues.filter = filterValue;
+  }
+}

--- a/src/app/phase-team-response/phase-team-response.component.html
+++ b/src/app/phase-team-response/phase-team-response.component.html
@@ -12,6 +12,7 @@
     </mat-menu>
   </div>
 
+  <app-issues-overview [teamFilter]="teamFilter"></app-issues-overview>
   <app-issues-pending [teamFilter]="teamFilter"></app-issues-pending>
   <app-issues-responded [teamFilter]="teamFilter"></app-issues-responded>
   <app-issues-faulty [teamFilter]="teamFilter"></app-issues-faulty>

--- a/src/app/phase-team-response/phase-team-response.module.ts
+++ b/src/app/phase-team-response/phase-team-response.module.ts
@@ -7,6 +7,7 @@ import { SharedModule } from '../shared/shared.module';
 import { ViewIssueModule } from '../shared/view-issue/view-issue.module';
 import { IssueComponent } from './issue/issue.component';
 import { IssuesFaultyComponent } from './issues-faulty/issues-faulty.component';
+import { IssuesOverviewComponent } from './issues-overview/issues-overview.component';
 import { IssuesPendingComponent } from './issues-pending/issues-pending.component';
 import { IssuesRespondedComponent } from './issues-responded/issues-responded.component';
 import { PhaseTeamResponseRoutingModule } from './phase-team-response-routing.module';
@@ -22,6 +23,13 @@ import { PhaseTeamResponseComponent } from './phase-team-response.component';
     MarkdownModule.forChild(),
     IssueTablesModule
   ],
-  declarations: [PhaseTeamResponseComponent, IssueComponent, IssuesPendingComponent, IssuesRespondedComponent, IssuesFaultyComponent]
+  declarations: [
+    PhaseTeamResponseComponent,
+    IssueComponent,
+    IssuesOverviewComponent,
+    IssuesPendingComponent,
+    IssuesRespondedComponent,
+    IssuesFaultyComponent
+  ]
 })
 export class PhaseTeamResponseModule {}


### PR DESCRIPTION
### Summary:
Adds an overview table for team-response phase so all issues regardless of status appears in a consolidated table.

### Changes Made:
* Adds an additional table view for team-response phase
Before:
<img width="1410" alt="image" src="https://github.com/joyngjr/CATcher/assets/97519138/ca22762c-64b6-4252-9663-60970c71c23a">


After:
<img width="1412" alt="image" src="https://github.com/joyngjr/CATcher/assets/97519138/5f05cdbe-476c-48b9-b0fa-053e15998f17">

### Proposed Commit Message:
```
Currently, for the team-response phase, each issue will appear under one of 3 tables.
However, would it be easier for teams to keep track of their issues if there is a main table 
where all issues are kept regardless of status?
```