### PR TITLE
Modify behaviour of sorting by assignee

### DIFF
--- a/src/app/shared/issue-tables/issue-sorter.ts
+++ b/src/app/shared/issue-tables/issue-sorter.ts
@@ -14,8 +14,6 @@ export function getSortedData(sort: MatSort, data: Issue[]): Issue[] {
         return direction * compareByIssueType(a.type, b.type);
       case 'severity':
         return direction * compareBySeverity(a.severity, b.severity);
-      case 'assignees':
-        return direction * compareByStringValue(a.assignees.join(', '), b.assignees.join(', '));
       case 'teamAssigned':
         return direction * compareByStringValue(a.teamAssigned.id, b.teamAssigned.id);
       case 'Todo Remaining':

--- a/src/app/shared/issue-tables/issue-tables.component.html
+++ b/src/app/shared/issue-tables/issue-tables.component.html
@@ -94,7 +94,7 @@
 
   <!--Assignee Column-->
   <ng-container matColumnDef="assignees">
-    <mat-header-cell mat-header-cell *matHeaderCellDef mat-sort-header> Assignees </mat-header-cell>
+    <mat-header-cell mat-header-cell *matHeaderCellDef> Assignees </mat-header-cell>
     <mat-cell *matCellDef="let issue">
       <span (click)="$event.stopPropagation()" style="cursor: default" *ngIf="issue.assignees.length !== 0">
         {{ issue.assignees.join(', ') }}

--- a/tests/app/shared/issue-tables/issue-sorter.spec.ts
+++ b/tests/app/shared/issue-tables/issue-sorter.spec.ts
@@ -16,17 +16,6 @@ describe('issuer-sorter', () => {
     const todoIssuesList: Issue[] = [moderationIssue, otherModerationIssue];
     const matSort: MatSort = new MatSort();
 
-    it('sorts issues based on their assignees correctly', () => {
-      matSort.active = 'assignees';
-      matSort.direction = 'asc';
-      const sortedIssuesByAssigneesAsc = getSortedData(matSort, issuesList);
-      assertOrder(sortedIssuesByAssigneesAsc, dummyIssue, otherDummyIssue);
-
-      matSort.direction = 'desc';
-      const sortedIssuesByAssigneesDesc = getSortedData(matSort, issuesList);
-      assertOrder(sortedIssuesByAssigneesDesc, otherDummyIssue, dummyIssue);
-    });
-
     it('sorts issues based on their string fields correctly', () => {
       matSort.active = 'title';
       matSort.direction = 'asc';


### PR DESCRIPTION
### Summary:
Incomplete modification of sorting by assignee. Currently, the ability to sort issues by assignee in ascending/descending order has been removed.

### Changes Made:
* Remove sorting feature for assignee in issues table

Before
<img width="1398" alt="image" src="https://github.com/joyngjr/CATcher/assets/97519138/c84056f2-2446-4596-a33f-491fdafe2db0">

After
<img width="1411" alt="image" src="https://github.com/joyngjr/CATcher/assets/97519138/ba141c87-3711-40d9-8907-77177e29ef86">

### Proposed Commit Message:
```
Currently, issues in a table can be sorted in ascending/descending alphabetical order. 
However, would it be better to implement a filter by name since a more likely usage scenario is for 
users to search for issues that fall under a particular student?
```