### PR TITLE
Add UIFlaw type

### DIFF
--- a/src/app/core/services/label.service.ts
+++ b/src/app/core/services/label.service.ts
@@ -19,6 +19,7 @@ const COLOR_RED_PALE = 'ffe0e0';
 const COLOR_RED_LIGHT = 'ffcccc';
 const COLOR_RED = 'ff9999';
 const COLOR_RED_DARK = 'ff6666';
+const COLOR_PINK = 'f8c8dc';
 
 const COLOR_PURPLE_LIGHT = 'd966ff';
 const COLOR_PURPLE = '9900cc';
@@ -63,6 +64,7 @@ const FEATURE_FLAW_DEFINITION =
   'of the project.</p>';
 const DOCUMENTATION_BUG_DEFINITION =
   '<p>A flaw in the documentation ' + '<span style="color:grey;">e.g., a missing step, a wrong instruction, typos</span></p>';
+const UI_FLAW_DEFINITION = '<p>A flaw in the UI ' + '<span style="color:grey;">e.g., words are cut off</span></p>';
 
 const ACCEPTED_DEFINITION = '<p>You accept it as a bug.</p>';
 const NOT_IN_SCOPE_DEFINITION =
@@ -101,7 +103,8 @@ const REQUIRED_LABELS = {
   type: {
     DocumentationBug: new Label('type', 'DocumentationBug', COLOR_PURPLE_LIGHT, DOCUMENTATION_BUG_DEFINITION),
     FeatureFlaw: new Label('type', 'FeatureFlaw', COLOR_PURPLE_LIGHT, FEATURE_FLAW_DEFINITION),
-    FunctionalityBug: new Label('type', 'FunctionalityBug', COLOR_PURPLE, FUNCTIONALITY_BUG_DEFINITION)
+    FunctionalityBug: new Label('type', 'FunctionalityBug', COLOR_PURPLE, FUNCTIONALITY_BUG_DEFINITION),
+    UIFlaw: new Label('type', 'UIFlaw', COLOR_PINK, UI_FLAW_DEFINITION)
   },
   response: {
     Accepted: new Label('response', 'Accepted', COLOR_GREEN, ACCEPTED_DEFINITION),


### PR DESCRIPTION
### Summary:
Follow DG Tutorial to add a new issue type called UIFlaw

### Changes Made:
* Adds a new bug type for users to select from

Before
<img width="326" alt="image" src="https://github.com/joyngjr/CATcher/assets/97519138/dc098c1e-643e-4c3a-9d79-78be6217d870">

After
<img width="325" alt="image" src="https://github.com/joyngjr/CATcher/assets/97519138/71b8bad3-22f7-44c3-978e-83dc9623c386">

### Proposed Commit Message:
```
Add a new bug type for users to select from
```
